### PR TITLE
Updated feature expression

### DIFF
--- a/src/pkg.lisp
+++ b/src/pkg.lisp
@@ -75,7 +75,7 @@
 ;;; CLM package stubs
 ;;;
 
-#-clm
+#-(and clm (not opusmodus))
 (defpackage :clm
   (:use :common-lisp)
   #+openmcl (:import-from :ccl #:open-shared-library)
@@ -90,7 +90,7 @@
 
 (in-package :clm)
 
-#-clm
+#-(and clm (not opusmodus))
 (progn
 (defstub clm-load)
 (defstub dac)


### PR DESCRIPTION
The full CM code can be loaded into Opusmodus (running in CCL) so that CM and Opmo can be used alongside each other (e.g., CM patterns used in Opmo).

However, the new Opusmodus 1.3 now includes CLM (and adds it to `*features*`), but does not define the package CLM. Opmo now likely loads the whole CLM code into its main package instead for simplicity (I don't agree with such approach, but there you go).

Because of this, in Opusmodus 1.3 loading CM results in an error that the CLM package is not found. This minor change to two feature expressions avoids that problem without changing anything for users on other platforms. I tested the change in Opusmodus 1.3.

Thanks for considering this pull request! 

Best,
Torsten 